### PR TITLE
[001-USER-API] Spring Security의 UsernamePasswordAuthenticationFilter를 활용한 JWT 기반 로그인 및 회원가입, 인증인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // json token 생성 설정
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // 또는 jjwt-gson
+
     // test 설정
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/portfolio/ourverse/common/config/AppConfig.java
+++ b/src/main/java/org/portfolio/ourverse/common/config/AppConfig.java
@@ -1,0 +1,20 @@
+package org.portfolio.ourverse.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    /*
+        password 모듈
+     */
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
+++ b/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.portfolio.ourverse.common.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.portfolio.ourverse.common.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Slf4j
 @Configuration
@@ -19,6 +21,9 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     /*
     Spring Security 관련 모듈이다.
      */
@@ -34,7 +39,7 @@ public class SecurityConfig {
                                 .requestMatchers("/auth/**").permitAll()
                                 .requestMatchers("/v3/**", "/swagger-ui/**").permitAll() // swagger 설정
                                 .anyRequest().denyAll()
-                );
+                ).addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/org/portfolio/ourverse/common/constant/Auth.java
+++ b/src/main/java/org/portfolio/ourverse/common/constant/Auth.java
@@ -1,0 +1,19 @@
+package org.portfolio.ourverse.common.constant;
+
+import lombok.Data;
+
+/*
+    회원가입 및 로그인 시 사용하는 DTO
+ */
+public class Auth {
+    @Data
+    public static class SignUp{
+        private String username;
+        private String email;
+        private String phone;
+        private String password;
+        private String name;
+        private String nickname;
+        private Authority role;
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/common/constant/Auth.java
+++ b/src/main/java/org/portfolio/ourverse/common/constant/Auth.java
@@ -1,5 +1,6 @@
 package org.portfolio.ourverse.common.constant;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 /*
@@ -8,12 +9,28 @@ import lombok.Data;
 public class Auth {
     @Data
     public static class SignUp{
+
+        @NotBlank(message = "username을 입력해야합니다.")
         private String username;
+        @NotBlank(message = "email을 입력해야합니다.")
         private String email;
+        @NotBlank(message = "phone을 입력해야합니다.")
         private String phone;
+        @NotBlank(message = "passowrd를 입력해야합니다.")
         private String password;
+        @NotBlank(message = "name을 입력해야합니다.")
         private String name;
+        @NotBlank(message = "nickname을 입력해야합니다.")
         private String nickname;
         private Authority role;
+    }
+
+    @Data
+    public static class SignIn {
+
+        @NotBlank(message = "username을 입력해야합니다.")
+        private String username;
+        @NotBlank(message = "password를 입력해야합니다.")
+        private String password;
     }
 }

--- a/src/main/java/org/portfolio/ourverse/common/constant/Authority.java
+++ b/src/main/java/org/portfolio/ourverse/common/constant/Authority.java
@@ -1,0 +1,5 @@
+package org.portfolio.ourverse.common.constant;
+
+public enum Authority {
+    ROLE_ARTIST, ROLE_FAN
+}

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -8,6 +8,9 @@ public enum ExceptionCode {
     /*
         400 : Request, Response 오류
      */
+    ALREADY_EXISTS_PHONE(HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다."),
+    ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 email입니다."),
+    ALREADY_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 username입니다."),
     WRONG_SOMETHING(HttpStatus.BAD_REQUEST, "잘못된 요청을 했습니다."),
     WRONG_TYPE_ROLE(HttpStatus.BAD_REQUEST, "잘못된 타입의 role를 입력했습니다.")
     ;

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -13,6 +13,7 @@ public enum ExceptionCode {
     ALREADY_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 username입니다."),
 
     NOT_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "존재하지 않는 username입니다."),
+    NOT_AUTHENTICATE(HttpStatus.BAD_REQUEST, "인증되지 않은 사용자입니다."),
 
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "password가 잘못됐습니다."),
     WRONG_SOMETHING(HttpStatus.BAD_REQUEST, "잘못된 요청을 했습니다."),

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -11,6 +11,10 @@ public enum ExceptionCode {
     ALREADY_EXISTS_PHONE(HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 email입니다."),
     ALREADY_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 username입니다."),
+
+    NOT_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "존재하지 않는 username입니다."),
+
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "password가 잘못됐습니다."),
     WRONG_SOMETHING(HttpStatus.BAD_REQUEST, "잘못된 요청을 했습니다."),
     WRONG_TYPE_ROLE(HttpStatus.BAD_REQUEST, "잘못된 타입의 role를 입력했습니다.")
     ;

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/GlobalExceptionHandler.java
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResult> ExceptionHandle(Exception e){
-        log.info("{} ->", e.getMessage());
+        log.info("{} : {}->", e.getClass(), e.getMessage());
         var result = BaseResult.builder()
                 .status(HttpStatus.SERVICE_UNAVAILABLE)
                 .message("알 수 없는 오류가 발생했습니다.")

--- a/src/main/java/org/portfolio/ourverse/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/portfolio/ourverse/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package org.portfolio.ourverse.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /*
+        헤더를 읽어 토큰을 통해 인증정보 생성.
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveTokenFromRequest(request);
+
+        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)){
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private static String resolveTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader(TOKEN_HEADER);
+        if(!ObjectUtils.isEmpty(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)){
+            return bearerToken.substring(TOKEN_PREFIX.length());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/portfolio/ourverse/common/security/JwtTokenProvider.java
@@ -6,8 +6,13 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.portfolio.ourverse.common.constant.Authority;
+import org.portfolio.ourverse.src.service.AuthService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -16,10 +21,12 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
+    private final AuthService authService;
     @Value("${spring.jwt.secret}")
     private String secretKey;
 
     private static final String KEY_ROLE = "role";
+    private static final String KEY_USERID = "userId";
     private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
 
     private SecretKey getSigningKey(){
@@ -30,9 +37,10 @@ public class JwtTokenProvider {
     /*
        토큰 생성
      */
-    public String generateToken(String username, Authority role) {
+    public String generateToken(String username, Authority role, Long userId) {
         Claims claims = Jwts.claims().setSubject(username);
         claims.put(KEY_ROLE, role);
+        claims.put(KEY_USERID, userId); // pk
 
         var now = new Date();
         var expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME); // 만료 시간
@@ -44,5 +52,39 @@ public class JwtTokenProvider {
                 .signWith(this.getSigningKey())
                 .compact();
 
+    }
+
+    /*
+    토큰 만료일 확인
+     */
+    public boolean validateToken(String token) {
+        if(!StringUtils.hasText(token)) return false;
+
+        var claims = this.parseClaims(token);
+
+        return claims.getExpiration().after(new Date()); // 만료일 확인
+    }
+
+    /*
+    token 파싱
+     */
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(this.getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    /*
+    token으로부터 userdetail 가져와 인증 정보 전달
+     */
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = authService.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String getUsername(String token) {
+        return parseClaims(token).getSubject();
     }
 }

--- a/src/main/java/org/portfolio/ourverse/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/portfolio/ourverse/common/security/JwtTokenProvider.java
@@ -1,0 +1,48 @@
+package org.portfolio.ourverse.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.constant.Authority;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    private static final String KEY_ROLE = "role";
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
+
+    private SecretKey getSigningKey(){
+        byte[] keyBytes = Decoders.BASE64.decode(this.secretKey);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /*
+       토큰 생성
+     */
+    public String generateToken(String username, Authority role) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put(KEY_ROLE, role);
+
+        var now = new Date();
+        var expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME); // 만료 시간
+
+        return Jwts.builder()
+                .addClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiredDate)
+                .signWith(this.getSigningKey())
+                .compact();
+
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/model/UserVO.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/UserVO.java
@@ -1,0 +1,15 @@
+package org.portfolio.ourverse.src.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserVO {
+    private Long userId;
+    private String username;
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/UserRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/UserRepository.java
@@ -3,8 +3,11 @@ package org.portfolio.ourverse.src.persist;
 import org.portfolio.ourverse.src.persist.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByUsername(String username);
     Boolean existsByEmail(String email);
     Boolean existsByPhone(String phone);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/UserRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/UserRepository.java
@@ -1,0 +1,10 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.src.persist.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Boolean existsByUsername(String username);
+    Boolean existsByEmail(String email);
+    Boolean existsByPhone(String phone);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/User.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/User.java
@@ -1,0 +1,34 @@
+package org.portfolio.ourverse.src.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+import org.portfolio.ourverse.common.constant.Authority;
+import org.portfolio.ourverse.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String email;
+    private String phone;
+    private String password;
+    private String name;
+    private String nickname;
+    private String groupname;
+
+    @Enumerated(EnumType.STRING)
+    private Authority role;
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/User.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/User.java
@@ -8,6 +8,12 @@ import lombok.NoArgsConstructor;
 import org.hibernate.envers.AuditOverride;
 import org.portfolio.ourverse.common.constant.Authority;
 import org.portfolio.ourverse.common.entity.BaseEntity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Getter
@@ -15,7 +21,7 @@ import org.portfolio.ourverse.common.entity.BaseEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,4 +37,9 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Authority role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role.name()));
+    }
 }

--- a/src/main/java/org/portfolio/ourverse/src/service/AuthService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/AuthService.java
@@ -54,4 +54,18 @@ public class AuthService {
         }
     }
 
+    public User authentication(Auth.SignIn form) {
+
+        // 1. user 찾기
+        User user = userRepository.findByUsername(form.getUsername()).orElseThrow(
+                () -> new BaseException(ExceptionCode.NOT_EXISTS_USERNAME)
+        );
+
+        // 2. 해당 user의 password와 맞는지 확인하기.
+        if(!passwordEncoder.matches(form.getPassword(), user.getPassword())){
+            throw new BaseException(ExceptionCode.WRONG_SOMETHING);
+        }
+
+        return user;
+    }
 }

--- a/src/main/java/org/portfolio/ourverse/src/service/AuthService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/AuthService.java
@@ -1,0 +1,57 @@
+package org.portfolio.ourverse.src.service;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.constant.Auth;
+import org.portfolio.ourverse.common.exceptions.BaseException;
+import org.portfolio.ourverse.common.exceptions.ExceptionCode;
+import org.portfolio.ourverse.src.persist.UserRepository;
+import org.portfolio.ourverse.src.persist.entity.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void register(Auth.SignUp form){
+
+        // 1. 이미 존재하는 사용자인지 확인.
+        checkExistUser(form);
+
+        // 2. User 객체 생성 후 저장.
+        userRepository.save(
+            User.builder()
+                .username(form.getUsername())
+                .email(form.getEmail())
+                .phone(form.getPhone())
+                .password(passwordEncoder.encode(form.getPassword()))
+                .name(form.getName())
+                .nickname(form.getNickname())
+                .role(form.getRole())
+                .build()
+        );
+    }
+
+    private void checkExistUser(Auth.SignUp form) {
+        // 0. username(ID) unique한지 확인.
+        if(userRepository.existsByUsername(form.getUsername())){
+            throw new BaseException(ExceptionCode.ALREADY_EXISTS_USERNAME);
+        }
+
+        // 1. 전화번호 unique한지 확인.
+        if(userRepository.existsByPhone(form.getPhone())){
+            throw new BaseException(ExceptionCode.ALREADY_EXISTS_PHONE);
+        }
+
+        // 2. 이메일 unique한지 확인.
+        if(userRepository.existsByEmail(form.getEmail())){
+            throw new BaseException(ExceptionCode.ALREADY_EXISTS_EMAIL);
+        }
+    }
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
         var user = authService.authentication(form);
 
         // 2. token 발급하기.
-        var token = jwtTokenProvider.generateToken(user.getUsername(), user.getRole());
+        var token = jwtTokenProvider.generateToken(user.getUsername(), user.getRole(), user.getId());
 
         return ResponseEntity.ok(token);
     }

--- a/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
@@ -1,11 +1,24 @@
 package org.portfolio.ourverse.src.web;
 
 import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.constant.Auth;
+import org.portfolio.ourverse.src.service.AuthService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    // 회원가입 기능.
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(@RequestBody Auth.SignUp form) {
+        authService.register(form);
+        return ResponseEntity.ok("회원가입에 성공했습니다.");
+    }
 
 }

--- a/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/AuthController.java
@@ -1,7 +1,9 @@
 package org.portfolio.ourverse.src.web;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.portfolio.ourverse.common.constant.Auth;
+import org.portfolio.ourverse.common.security.JwtTokenProvider;
 import org.portfolio.ourverse.src.service.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,12 +15,29 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    // 회원가입 기능.
+    /*
+    회원가입
+     */
     @PostMapping("/sign-up")
-    public ResponseEntity<?> signUp(@RequestBody Auth.SignUp form) {
+    public ResponseEntity<String> signUp(@Valid @RequestBody Auth.SignUp form) {
         authService.register(form);
         return ResponseEntity.ok("회원가입에 성공했습니다.");
+    }
+
+    /*
+    로그인
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<String> signIn(@Valid @RequestBody Auth.SignIn form){
+        // 1. 인증하기
+        var user = authService.authentication(form);
+
+        // 2. token 발급하기.
+        var token = jwtTokenProvider.generateToken(user.getUsername(), user.getRole());
+
+        return ResponseEntity.ok(token);
     }
 
 }


### PR DESCRIPTION
# 개요 
Spring Security의 UsernamePasswordAuthenticationFilter를 활용한 JWT 기반 로그인 및 회원가입, 인증 인가를 구현했습니다.

# 변경 사항
1. 회원가입 시 UserRepository를 통해 정보를 저장함.
2. 로그인 시 JwtTokenProvider를 통해 JWT 토큰을 발급해줌.
3. 발급된 JWT 토큰을 통해 JwtAuthenticationFilter로 SecurityContextHolder에 Authentication를 등록하고, UsernamePasswordAuthenticationFilter로 넘겨줌.
4. User 엔티티는 UserDetails를, AuthService는 UserDetailService를 구현하여 Spring Security에서 사용됨.
5. User의 role를 통해 Artist와 Fan을 구분함.
6. Jwt 토큰의 유효 기간을 1시간으로 설정하여 그 이상 지나갈 경우 토큰은 사용할 수 없게 됨.
7. @Valid 어노테이션을 통해 Controller 단에서 형식적 validation을 구현함.

# 테스트 및 테스트 결과
[x] 회원가입 시 정보가 DB에 저장되는지 확인.
[x] 회원가입 시 중복되면 안되는 정보(username, email, phone)가 예외처리가 되는지 확인 
[x] 로그인 시 토큰이 제대로 발급되는지 확인.
[x] 토큰 만료 시간이 지나면 사용이 불가능해지는지 확인.
[x] 아래와 같은 별도의 testController를 만들어 role에 의한 인가 기능이 제대로 동작하는지 확인
[x] 아래와 같은 별도의 testController를 만들어 현재 로그인한 유저의 정보를 제대로 가져올 수 있는지 확인

<img width="838" alt="image" src="https://github.com/taeGnues/Ourverse/assets/112752089/576b5267-e671-4981-827d-e60add8231c6">

# 참고 사항
- 아직 회원가입 및 로그인 시 발생하는 Exception들에 대해 제대로 된 처리를 구현하진 않음.

# 리뷰 요청 사항
- Jwt 토큰은 만료시간이 존재해 자연스럽게 로그아웃이 진행되는데, 별도의 로그아웃을 구현하는 편이 나을지 궁금합니다.