### PR TITLE
[003-COMMENT&LIKE-API] 댓글 CRUD 및 댓글 좋아요, 게시글 좋아요 기능 구현, QueryDSL로 게시글 및 댓글 조회 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@
 | 게시글 목록 조회 기능  | 필수 |  O   |
 | 특정 게시글 조회 기능  | 필수 |  O   |
 | 게시글 CRUD      | 필수 |  O   |
-| 댓글 목록 조회 기능   | 필수 |      |
-| 댓글 CRUD       | 필수 |      |
-| 좋아요 기능        | 필수 |      |
+| 댓글 목록 조회 기능   | 필수 |  O   |
+| 댓글 CRUD       | 필수 |  O   |
+| 좋아요 기능        | 필수 |  O   |
 | 신고 기능         | 보조 |      | 
 | 신고 목록 조회 기능   | 보조 |      |
 | 어드민 기능        | 보조 |      |
@@ -140,6 +140,9 @@
   <img alt="java" src="https://img.shields.io/badge/java-007396?style=for-the-badge&logo=java&logoColor=white"> 
   <img alt="spring" src="https://img.shields.io/badge/spring-6DB33F?style=for-the-badge&logo=spring&logoColor=white">
   <img alt="spring security" src="https://img.shields.io/badge/spring security-6DB33F?style=for-the-badge&logo=spring security&logoColor=white">
+  <div></div>
+  <img alt="spring data jpa" src="https://img.shields.io/badge/spring data jpa-000000?style=for-the-badge&logo=spring data jpa&logoColor=white">
+  <img alt="querydsl" src="https://img.shields.io/badge/querydsl-000000?style=for-the-badge&logo=query dsl&logoColor=white">
   <div></div>
   <img alt="elastic search" src="https://img.shields.io/badge/elasticsearch-005571?style=for-the-badge&logo=elasticsearch&logoColor=white">
   <img alt="redis" src="https://img.shields.io/badge/redis-ff4438?style=for-the-badge&logo=redis&logoColor=white">

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.5'
+
+    // querydsl 추가
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'org.portfolio'
@@ -27,6 +30,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Spring Validation 설정
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.0'
@@ -58,4 +67,23 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl{
+    jpa=true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/doc/TROUBLE_SHOOTING.md
+++ b/doc/TROUBLE_SHOOTING.md
@@ -51,6 +51,45 @@ select u.id, u.username, u.email from user u where u.user_id = f.user_id -- (2)
 
 https://velog.io/@j3beom/JPA-%ED%94%84%EB%A1%9D%EC%8B%9CProxy-%EA%B8%B0%EB%B3%B8
 
+## QueryDSL 초기 설정하기
+### Trouble
+- querydsl의 설정은 다음과 같은 방식으로 진행한다.
+https://blog.naver.com/innogrid/222725730056
+
+- 구조 잡기
+https://velog.io/@soyeon207/QueryDSL-Spring-Boot-%EC%97%90%EC%84%9C-QueryDSL-JPA-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0
+
+- querydsl 사용이유
+http://ssow93.tistory.com/69
+
+- 오류 발생 시 :
+https://lahezy.tistory.com/94
+
+- 동적 정렬하기 : https://dingdingmin-back-end-developer.tistory.com/entry/Springboot-JPA-Querydsl-%EB%8F%99%EC%A0%81-%EC%A0%95%EB%A0%AC-OrderSpecifier
+
+## PathVariable 설정 문제 (build and run - intellij로 설정 시)
+### Trouble
+querydsl를 사용하기 위해 기존 gradle 대신 intellij를 사용했다. 이때, 
+```java
+    @PatchMapping("/{groupname}")
+    public ResponseEntity<String> updateGroupName(@PathVariable String groupname) {
+        log.info("Updating group name {}", groupname);
+        try{
+            authService.updateGroupName(GroupName.valueOf(groupname));
+        }catch (IllegalArgumentException e){
+            throw new BaseException(ExceptionCode.WRONG_GROUPNAME);
+        }
+        return ResponseEntity.ok("그룹 가입에 성공하셨습니다.");
+    }
+```
+위와 같이 patchvariable를 사용해도 적용이 안된다!
+
+### Solution
+
+
+설정 변경 적용을 위한 out 폴더 삭제 : https://sehyeona.tistory.com/32
+
+
 ## N+1 문제점 
 처음 프로젝트 설계시 게시판 글 조회 시 댓글 목록도 함께 조회를 하고자 하였습니다. 그러자 한번 게시글 조회시 해당 게시글에 작성된 모든 댓글들도 함께 조회가 되었습니다.
 그리고 이 부분들이 한번에 조회된 것이 아닌, 
@@ -63,3 +102,12 @@ https://velog.io/@j3beom/JPA-%ED%94%84%EB%A1%9D%EC%8B%9CProxy-%EA%B8%B0%EB%B3%B8
 
 2. API 분리
 ...
+
+
+궁금증 : 게시글 조회시 댓글도 함께 가져오는게 좋을까?
+댓글 가져오는 API, 게시글 가져오는 API 분리하는게 좋지 않을까?
+
+cascade로 게시글-댓글-댓글좋아요을 묶는게 바람직할까?
+게시글의 삭제는 댓글, 댓글 좋아요 삭제로 생명주기가 묶이지만
+댓글 삭제는 게시글의 삭제 이전에도 이루어질 수 있고,
+댓글 좋아요 삭제 역시 댓글, 게시글의 삭제 이전에도 이뤄질 수 있다.

--- a/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
+++ b/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                                 .requestMatchers("/feed/**").hasAnyRole("FAN", "ARTIST")
                                 .requestMatchers("/group/**").hasAnyRole("FAN", "ARTIST")
                                 .requestMatchers("/comment/**").hasAnyRole("FAN", "ARTIST")
+                                .requestMatchers("/feed-like/**").hasAnyRole("FAN", "ARTIST")
+                                .requestMatchers("/comment-like/**").hasAnyRole("FAN", "ARTIST")
                                 .anyRequest().denyAll()
                 ).addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
+++ b/src/main/java/org/portfolio/ourverse/common/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                                 .requestMatchers("/v3/**", "/swagger-ui/**").permitAll() // swagger 설정
                                 .requestMatchers("/feed/**").hasAnyRole("FAN", "ARTIST")
                                 .requestMatchers("/group/**").hasAnyRole("FAN", "ARTIST")
+                                .requestMatchers("/comment/**").hasAnyRole("FAN", "ARTIST")
                                 .anyRequest().denyAll()
                 ).addFilterBefore(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -14,6 +14,7 @@ public enum ExceptionCode {
 
     NOT_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "존재하지 않는 username입니다."),
     NOT_EXISTS_FEED(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
+    NOT_EXISTS_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
     NOT_AUTHENTICATE(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     USER_NOT_GROUP(HttpStatus.UNAUTHORIZED, "가입된 GROUP이 없습니다."),
 

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -12,11 +12,13 @@ public enum ExceptionCode {
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 email입니다."),
     ALREADY_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 username입니다."),
     ALREADY_EXISTS_FEEDLIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),
+    ALREADY_EXISTS_COMMENTLIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),
 
     NOT_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "존재하지 않는 username입니다."),
     NOT_EXISTS_FEED(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
     NOT_EXISTS_FEEDLIKE(HttpStatus.BAD_REQUEST, "존재하지 않는 좋아요 정보입니다."),
-    NOT_EXISTS_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
+    NOT_EXISTS_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 댓글입니다."),
+    NOT_EXISTS_COMMENTLIKE(HttpStatus.BAD_REQUEST, "존재하지 않는 좋아요 정보입니다."),
     NOT_AUTHENTICATE(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     USER_NOT_GROUP(HttpStatus.UNAUTHORIZED, "가입된 GROUP이 없습니다."),
 

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/ExceptionCode.java
@@ -11,9 +11,11 @@ public enum ExceptionCode {
     ALREADY_EXISTS_PHONE(HttpStatus.BAD_REQUEST, "이미 존재하는 전화번호입니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 email입니다."),
     ALREADY_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 username입니다."),
+    ALREADY_EXISTS_FEEDLIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),
 
     NOT_EXISTS_USERNAME(HttpStatus.BAD_REQUEST, "존재하지 않는 username입니다."),
     NOT_EXISTS_FEED(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
+    NOT_EXISTS_FEEDLIKE(HttpStatus.BAD_REQUEST, "존재하지 않는 좋아요 정보입니다."),
     NOT_EXISTS_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 게시물입니다."),
     NOT_AUTHENTICATE(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     USER_NOT_GROUP(HttpStatus.UNAUTHORIZED, "가입된 GROUP이 없습니다."),
@@ -27,7 +29,7 @@ public enum ExceptionCode {
     /*
         500 : Server 오류
      */
-    DB_NOT_EXISTS_USER(HttpStatus.INTERNAL_SERVER_ERROR, "존재하지 않는 사용자입니다.");
+    NOT_EXISTS_USER(HttpStatus.INTERNAL_SERVER_ERROR, "존재하지 않는 사용자입니다.");
 
     ExceptionCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;

--- a/src/main/java/org/portfolio/ourverse/common/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/org/portfolio/ourverse/common/exceptions/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.portfolio.ourverse.common.exceptions;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.portfolio.ourverse.common.constant.BaseResult;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,19 @@ public class GlobalExceptionHandler {
                 .build();
 
         return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
+    }
+
+    /*
+    jwt 토큰 만료
+     */
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<BaseResult> ExpiredJwtExceptionHandle(){
+        var result = BaseResult.builder()
+                .status(HttpStatus.UNAUTHORIZED)
+                .message("토큰이 만료됐습니다. 다시 로그인해주세요.")
+                .build();
+
+        return new ResponseEntity<>(result, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/portfolio/ourverse/src/model/CommentDTO.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/CommentDTO.java
@@ -4,16 +4,22 @@ import lombok.Builder;
 import lombok.Data;
 import org.portfolio.ourverse.src.persist.entity.Comment;
 
+import java.time.LocalDateTime;
+
 @Data
 @Builder
 public class CommentDTO {
     private String content;
     private String nickname;
+    private int commentLikeCnt;
+    private LocalDateTime createdAt;
 
     public static CommentDTO from(Comment m) {
         return CommentDTO.builder()
                 .content(m.getContent())
                 .nickname(m.getUser().getNickname())
+                .commentLikeCnt(m.getCommentLikeCnt())
+                .createdAt(m.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/org/portfolio/ourverse/src/model/CommentDTO.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/CommentDTO.java
@@ -1,0 +1,19 @@
+package org.portfolio.ourverse.src.model;
+
+import lombok.Builder;
+import lombok.Data;
+import org.portfolio.ourverse.src.persist.entity.Comment;
+
+@Data
+@Builder
+public class CommentDTO {
+    private String content;
+    private String nickname;
+
+    public static CommentDTO from(Comment m) {
+        return CommentDTO.builder()
+                .content(m.getContent())
+                .nickname(m.getUser().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/model/CommentOrderCondition.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/CommentOrderCondition.java
@@ -1,0 +1,12 @@
+package org.portfolio.ourverse.src.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CommentOrderCondition {
+    private boolean isCommentlikeCnt;
+    private boolean isCreatedAt;
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/model/CommentPostDTO.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/CommentPostDTO.java
@@ -1,0 +1,8 @@
+package org.portfolio.ourverse.src.model;
+
+import lombok.Data;
+
+@Data
+public class CommentPostDTO {
+    private String content;
+}

--- a/src/main/java/org/portfolio/ourverse/src/model/FeedOrderCondition.java
+++ b/src/main/java/org/portfolio/ourverse/src/model/FeedOrderCondition.java
@@ -1,0 +1,12 @@
+package org.portfolio.ourverse.src.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FeedOrderCondition {
+    private boolean isCommentCnt;
+    private boolean isFeedlikeCnt;
+    private boolean isCreatedAt;
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CommentLikeRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CommentLikeRepository.java
@@ -3,8 +3,10 @@ package org.portfolio.ourverse.src.persist;
 import org.portfolio.ourverse.src.persist.entity.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
     Optional<CommentLike> findFirstByCommentAndUser(Comment comment, User user);
+    void deleteAllByComment(Comment comment);
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/CommentLikeRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.src.persist.entity.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findFirstByCommentAndUser(Comment comment, User user);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
@@ -1,10 +1,8 @@
 package org.portfolio.ourverse.src.persist;
 
 import org.portfolio.ourverse.src.persist.entity.Comment;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByFeed_Id(Long id, Pageable pageable);
+public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
 }
+

--- a/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
@@ -1,0 +1,10 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.src.persist.entity.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByFeed_Id(Long id, Pageable pageable);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CommentRepository.java
@@ -1,8 +1,14 @@
 package org.portfolio.ourverse.src.persist;
 
 import org.portfolio.ourverse.src.persist.entity.Comment;
+import org.portfolio.ourverse.src.persist.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
+
+    List<Comment> findAllByFeed(Feed feed);
+    void deleteAllByFeed(Feed feed);
 }
 

--- a/src/main/java/org/portfolio/ourverse/src/persist/CustomCommentRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CustomCommentRepository.java
@@ -1,0 +1,10 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.src.model.CommentOrderCondition;
+import org.portfolio.ourverse.src.persist.entity.Comment;
+
+import java.util.List;
+
+public interface CustomCommentRepository {
+    List<Comment> findAllByFeed_IdWithCriteria(Long id, int pageNo, int pageSize, CommentOrderCondition form);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CustomCommentRepositoryImpl.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CustomCommentRepositoryImpl.java
@@ -1,0 +1,53 @@
+package org.portfolio.ourverse.src.persist;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.portfolio.ourverse.src.model.CommentOrderCondition;
+import org.portfolio.ourverse.src.persist.entity.Comment;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.portfolio.ourverse.src.persist.entity.QComment.comment;
+
+@Repository
+public class CustomCommentRepositoryImpl extends QuerydslRepositorySupport implements CustomCommentRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CustomCommentRepositoryImpl(EntityManager entityManager) {
+        super(Comment.class);
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<Comment> findAllByFeed_IdWithCriteria(Long id, int pageNo, int pageSize, CommentOrderCondition form) {
+
+        return jpaQueryFactory.selectFrom(comment)
+                .where(comment.feed.id.eq(id))
+                .orderBy(getOrderSpecifiers(form))
+                .limit(pageSize)
+                .offset(pageNo)
+                .stream().toList();
+    }
+
+    private OrderSpecifier[] getOrderSpecifiers(CommentOrderCondition form) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        if(form.isCreatedAt()){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, comment.createdAt));
+        }
+
+        if(form.isCommentlikeCnt()){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, comment.commentLikeCnt));
+        }
+
+
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+    }
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CustomFeedRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CustomFeedRepository.java
@@ -1,0 +1,11 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.common.constant.GroupName;
+import org.portfolio.ourverse.src.model.FeedOrderCondition;
+import org.portfolio.ourverse.src.persist.entity.Feed;
+
+import java.util.List;
+
+public interface CustomFeedRepository {
+    List<Feed> findAllByGroupNameWithCriteria(GroupName groupName, int pageNo, int pageSize, FeedOrderCondition form);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/CustomFeedRepositoryImpl.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/CustomFeedRepositoryImpl.java
@@ -1,0 +1,58 @@
+package org.portfolio.ourverse.src.persist;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.portfolio.ourverse.common.constant.GroupName;
+import org.portfolio.ourverse.src.model.FeedOrderCondition;
+import org.portfolio.ourverse.src.persist.entity.Feed;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.portfolio.ourverse.src.persist.entity.QFeed.feed;
+
+@Repository
+public class CustomFeedRepositoryImpl extends QuerydslRepositorySupport implements CustomFeedRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CustomFeedRepositoryImpl(EntityManager entityManager) {
+        super(Feed.class);
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<Feed> findAllByGroupNameWithCriteria(GroupName groupName, int pageNo, int pageSize, FeedOrderCondition form) {
+
+        return jpaQueryFactory.selectFrom(feed)
+                .where(feed.groupName.eq(groupName))
+                .orderBy(getOrderSpecifiers(form))
+                .limit(pageSize)
+                .offset(pageNo)
+                .stream().toList();
+    }
+
+    private OrderSpecifier[] getOrderSpecifiers(FeedOrderCondition form) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        if(form.isCreatedAt()){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, feed.createdAt));
+        }
+
+        if(form.isFeedlikeCnt()){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, feed.feedLikeCnt));
+        }
+
+        if(form.isCommentCnt()){
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, feed.commentCnt));
+        }
+
+
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+    }
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/FeedLikeRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/FeedLikeRepository.java
@@ -1,0 +1,12 @@
+package org.portfolio.ourverse.src.persist;
+
+import org.portfolio.ourverse.src.persist.entity.Feed;
+import org.portfolio.ourverse.src.persist.entity.FeedLike;
+import org.portfolio.ourverse.src.persist.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+    Optional<FeedLike> findFirstByFeedAndUser(Feed feed, User user);
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/FeedLikeRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/FeedLikeRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     Optional<FeedLike> findFirstByFeedAndUser(Feed feed, User user);
+    void deleteAllByFeed(Feed feed);
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/FeedRepository.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/FeedRepository.java
@@ -1,19 +1,14 @@
 package org.portfolio.ourverse.src.persist;
 
-import org.portfolio.ourverse.common.constant.GroupName;
 import org.portfolio.ourverse.src.persist.entity.Feed;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
-public interface FeedRepository extends JpaRepository<Feed, Long> {
+public interface FeedRepository extends JpaRepository<Feed, Long>, CustomFeedRepository {
 
     @Query("select f from Feed f where f.id = :feedId")
     Optional<Feed> findByIdWithUsers(@Param("feedId") Long id);
-
-    List<Feed> findAllByGroupName(GroupName groupName, Pageable pageable);
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/Comment.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/Comment.java
@@ -46,4 +46,12 @@ public class Comment extends BaseEntity {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void plusCommentLikeCnt() {
+        this.commentLikeCnt++;
+    }
+
+    public void minusCommentLikeCnt() {
+        this.commentLikeCnt--;
+    }
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/Comment.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/Comment.java
@@ -1,0 +1,49 @@
+package org.portfolio.ourverse.src.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+import org.portfolio.ourverse.common.entity.BaseEntity;
+import org.portfolio.ourverse.src.model.CommentPostDTO;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String content;
+    private boolean isHidden;
+    private int commentLikeCnt;
+
+    public static Comment of(CommentPostDTO commentPostDTO, Feed feed, User user){
+        return Comment.builder()
+                .feed(feed)
+                .user(user)
+                .content(commentPostDTO.getContent())
+                .isHidden(false)
+                .commentLikeCnt(0)
+                .build();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/CommentLike.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/CommentLike.java
@@ -1,0 +1,28 @@
+package org.portfolio.ourverse.src.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.envers.AuditOverride;
+import org.portfolio.ourverse.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class CommentLike extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/Feed.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/Feed.java
@@ -58,4 +58,12 @@ public class Feed extends BaseEntity{
     public void minusFeedLikeCnt() {
         this.feedLikeCnt--;
     }
+
+    public void plusCommentCnt() {
+        this.commentCnt++;
+    }
+
+    public void minusCommentCnt() {
+        this.commentCnt--;
+    }
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/Feed.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/Feed.java
@@ -51,4 +51,11 @@ public class Feed extends BaseEntity{
                 .build();
     }
 
+    public void plusFeedLikeCnt() {
+        this.feedLikeCnt++;
+    }
+
+    public void minusFeedLikeCnt() {
+        this.feedLikeCnt--;
+    }
 }

--- a/src/main/java/org/portfolio/ourverse/src/persist/entity/FeedLike.java
+++ b/src/main/java/org/portfolio/ourverse/src/persist/entity/FeedLike.java
@@ -1,0 +1,31 @@
+package org.portfolio.ourverse.src.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+import org.portfolio.ourverse.common.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+public class FeedLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.portfolio.ourverse.common.exceptions.BaseException;
 import org.portfolio.ourverse.common.exceptions.ExceptionCode;
 import org.portfolio.ourverse.src.model.CommentDTO;
+import org.portfolio.ourverse.src.model.CommentOrderCondition;
 import org.portfolio.ourverse.src.model.CommentPostDTO;
 import org.portfolio.ourverse.src.model.UserVO;
 import org.portfolio.ourverse.src.persist.CommentRepository;
@@ -12,9 +13,6 @@ import org.portfolio.ourverse.src.persist.UserRepository;
 import org.portfolio.ourverse.src.persist.entity.Comment;
 import org.portfolio.ourverse.src.persist.entity.Feed;
 import org.portfolio.ourverse.src.persist.entity.User;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,16 +59,11 @@ public class CommentService {
     }
 
     /*
-        현재 게시글 댓글 조회하기. (최신순)
+        현재 게시글 댓글 조회하기. (페이징 + 좋아요 순, 최신 순 기준으로 동적 정렬해서 리턴)
      */
-    public List<CommentDTO> getComments(Long feedId, int pageNo, int pageSize) {
-
-        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
-
-        return commentRepository.findAllByFeed_Id(feedId, pageable).stream()
-                .map(CommentDTO::from)
-                .toList();
-
+    public List<CommentDTO> getComments(Long feedId, int pageNo, int pageSize, CommentOrderCondition commentOrderCondition) {
+        return commentRepository.findAllByFeed_IdWithCriteria(feedId, pageNo, pageSize, commentOrderCondition)
+                .stream().map(CommentDTO::from).toList();
     }
 
     /*

--- a/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
@@ -7,6 +7,7 @@ import org.portfolio.ourverse.src.model.CommentDTO;
 import org.portfolio.ourverse.src.model.CommentOrderCondition;
 import org.portfolio.ourverse.src.model.CommentPostDTO;
 import org.portfolio.ourverse.src.model.UserVO;
+import org.portfolio.ourverse.src.persist.CommentLikeRepository;
 import org.portfolio.ourverse.src.persist.CommentRepository;
 import org.portfolio.ourverse.src.persist.FeedRepository;
 import org.portfolio.ourverse.src.persist.UserRepository;
@@ -25,6 +26,7 @@ public class CommentService {
 
     private final AuthService authService;
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final FeedRepository feedRepository;
     private final UserRepository userRepository;
 
@@ -54,6 +56,7 @@ public class CommentService {
         // 4. comment 생성 및 저장.
         Comment comment = Comment.of(form, feed, user);
         commentRepository.save(comment);
+        feed.plusCommentCnt();
 
         return comment.getId();
     }
@@ -72,7 +75,10 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long commentId) {
         Comment comment = checkAuthorityAndGetComment(commentId);
+        comment.getFeed().minusCommentCnt();
 
+        // 해당 댓글에 등록된 좋아요 모두 삭제하기.
+        commentLikeRepository.deleteAllByComment(comment);
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
@@ -38,7 +38,7 @@ public class CommentService {
 
         // 1. 유저 정보 가져오기.
         User user = userRepository.findById(userVO.getUserId()).orElseThrow(
-                () -> new BaseException(ExceptionCode.DB_NOT_EXISTS_USER)
+                () -> new BaseException(ExceptionCode.NOT_EXISTS_USER)
         );
 
         // 2. feedId로 feed 찾기.

--- a/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/CommentService.java
@@ -1,0 +1,106 @@
+package org.portfolio.ourverse.src.service;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.exceptions.BaseException;
+import org.portfolio.ourverse.common.exceptions.ExceptionCode;
+import org.portfolio.ourverse.src.model.CommentDTO;
+import org.portfolio.ourverse.src.model.CommentPostDTO;
+import org.portfolio.ourverse.src.model.UserVO;
+import org.portfolio.ourverse.src.persist.CommentRepository;
+import org.portfolio.ourverse.src.persist.FeedRepository;
+import org.portfolio.ourverse.src.persist.UserRepository;
+import org.portfolio.ourverse.src.persist.entity.Comment;
+import org.portfolio.ourverse.src.persist.entity.Feed;
+import org.portfolio.ourverse.src.persist.entity.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final AuthService authService;
+    private final CommentRepository commentRepository;
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    /*
+       현재 게시물 정보와 현재 유저 정보를 바탕으로 댓글 저장
+     */
+    @Transactional
+    public Long postComment(Long feedId, CommentPostDTO form) {
+        // 0. 현재 유저 확인
+        UserVO userVO = authService.getCurrentUserVO();
+
+        // 1. 유저 정보 가져오기.
+        User user = userRepository.findById(userVO.getUserId()).orElseThrow(
+                () -> new BaseException(ExceptionCode.DB_NOT_EXISTS_USER)
+        );
+
+        // 2. feedId로 feed 찾기.
+        Feed feed = feedRepository.findById(feedId).orElseThrow(
+                () -> new BaseException(ExceptionCode.NOT_EXISTS_FEED)
+        );
+
+        // 3. 현재 유저의 GROUP과 현재 게시글의 GROUP이 동일한지 확인.
+        if(!user.getGroupname().equals(feed.getGroupName())){
+            throw new BaseException(ExceptionCode.WRONG_ACCESS_AUTHORITY);
+        }
+
+        // 4. comment 생성 및 저장.
+        Comment comment = Comment.of(form, feed, user);
+        commentRepository.save(comment);
+
+        return comment.getId();
+    }
+
+    /*
+        현재 게시글 댓글 조회하기. (최신순)
+     */
+    public List<CommentDTO> getComments(Long feedId, int pageNo, int pageSize) {
+
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return commentRepository.findAllByFeed_Id(feedId, pageable).stream()
+                .map(CommentDTO::from)
+                .toList();
+
+    }
+
+    /*
+       현재 댓글 삭제하기.
+     */
+    @Transactional
+    public void deleteComment(Long commentId) {
+        Comment comment = checkAuthorityAndGetComment(commentId);
+
+        commentRepository.delete(comment);
+    }
+
+    /*
+        댓글 수정하기
+     */
+    @Transactional
+    public void updateComment(Long commentId, CommentPostDTO form) {
+        Comment comment = checkAuthorityAndGetComment(commentId);
+
+        comment.updateContent(form.getContent());
+    }
+
+    // 권한 확인 후 댓글 가져오기
+    private Comment checkAuthorityAndGetComment(Long commentId) {
+        UserVO userVO = authService.getCurrentUserVO();
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_COMMENT));
+        if(!comment.getUser().getId().equals(userVO.getUserId())){
+            throw new BaseException(ExceptionCode.WRONG_ACCESS_AUTHORITY);
+        }
+        return comment;
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/service/FeedLikeService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/FeedLikeService.java
@@ -1,0 +1,77 @@
+package org.portfolio.ourverse.src.service;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.exceptions.BaseException;
+import org.portfolio.ourverse.common.exceptions.ExceptionCode;
+import org.portfolio.ourverse.src.model.UserVO;
+import org.portfolio.ourverse.src.persist.FeedLikeRepository;
+import org.portfolio.ourverse.src.persist.FeedRepository;
+import org.portfolio.ourverse.src.persist.UserRepository;
+import org.portfolio.ourverse.src.persist.entity.Feed;
+import org.portfolio.ourverse.src.persist.entity.FeedLike;
+import org.portfolio.ourverse.src.persist.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedLikeService {
+    private final AuthService authService;
+    private final FeedLikeRepository feedLikeRepository;
+    private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+
+
+    @Transactional
+    public Long postFeedLike(Long id) {
+        UserVO userVO = authService.getCurrentUserVO();
+
+        // 1. 현재 유저 확인.
+        User user = userRepository.findById(userVO.getUserId())
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_USER));
+
+        // 2. 현재 보는 게시글 확인.
+        Feed feed = feedRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_FEED));
+
+        // 3. 이미 좋아요를 한 상태인지 확인.
+        if(feedLikeRepository.findFirstByFeedAndUser(feed, user).isPresent()){
+            throw new BaseException(ExceptionCode.ALREADY_EXISTS_FEEDLIKE);
+        }
+
+        // 4. 좋아요 등록.
+        FeedLike feedLike = FeedLike.builder()
+                .user(user)
+                .feed(feed)
+                .build();
+
+        // 5. 해당 feed의 좋아요 수 늘려주기.
+        feed.plusFeedLikeCnt();
+
+        feedLikeRepository.save(feedLike);
+
+        return feedLike.getId();
+    }
+
+    @Transactional
+    public void deleteFeedLike(Long id) {
+        UserVO userVO = authService.getCurrentUserVO();
+
+        // 1. 현재 유저 확인.
+        User user = userRepository.findById(userVO.getUserId())
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_USER));
+
+        // 2. 현재 보는 게시글 확인.
+        Feed feed = feedRepository.findById(id)
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_FEED));
+
+        // 3. 이미 좋아요를 한 상태인지 확인.
+        FeedLike feedLike = feedLikeRepository.findFirstByFeedAndUser(feed, user)
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_FEEDLIKE));
+
+        // 4. 해당 feed 좋아요 수 줄이기.
+        feed.minusFeedLikeCnt();
+
+        feedLikeRepository.delete(feedLike);
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/service/FeedService.java
+++ b/src/main/java/org/portfolio/ourverse/src/service/FeedService.java
@@ -37,7 +37,7 @@ public class FeedService {
         // 1. 현재 로그인한 유저 정보 확인.
         UserVO userVO = authService.getCurrentUserVO();
         User user = userRepository.findById(userVO.getUserId()).orElseThrow(
-                () -> new BaseException(ExceptionCode.DB_NOT_EXISTS_USER)
+                () -> new BaseException(ExceptionCode.NOT_EXISTS_USER)
         );
 
         // 1-1. 현재 유저가 가입된 group이 없다면, 오류 발생.
@@ -59,7 +59,7 @@ public class FeedService {
         // 1. 현재 사용자 정보 가져오기.
         UserVO userVO = authService.getCurrentUserVO();
         User user = userRepository.findById(userVO.getUserId()).orElseThrow(
-                () -> new BaseException(ExceptionCode.DB_NOT_EXISTS_USER)
+                () -> new BaseException(ExceptionCode.NOT_EXISTS_USER)
         );
 
         // 1-1. 현재 유저가 가입된 group이 없다면, 오류 발생.

--- a/src/main/java/org/portfolio/ourverse/src/web/CommentController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/CommentController.java
@@ -3,6 +3,7 @@ package org.portfolio.ourverse.src.web;
 import lombok.RequiredArgsConstructor;
 import org.portfolio.ourverse.src.model.CommentDTO;
 import org.portfolio.ourverse.src.model.CommentPostDTO;
+import org.portfolio.ourverse.src.model.CommentOrderCondition;
 import org.portfolio.ourverse.src.service.CommentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,10 +30,8 @@ public class CommentController {
 
     // 1. 특정 게시물 댓글 가져오기 - 최신순
     @GetMapping("/{feedId}")
-    public ResponseEntity<List<CommentDTO>> getComments(@PathVariable Long feedId, @RequestParam int pageNo, @RequestParam int pageSize) {
-
-        var res = commentService.getComments(feedId, pageNo, pageSize);
-
+    public ResponseEntity<List<CommentDTO>> getComments(@PathVariable Long feedId, @RequestParam int pageNo, @RequestParam int pageSize, @RequestBody CommentOrderCondition commentOrderCondition) {
+        var res = commentService.getComments(feedId, pageNo, pageSize, commentOrderCondition);
         return ResponseEntity.ok(res);
     }
 

--- a/src/main/java/org/portfolio/ourverse/src/web/CommentController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/CommentController.java
@@ -1,0 +1,61 @@
+package org.portfolio.ourverse.src.web;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.src.model.CommentDTO;
+import org.portfolio.ourverse.src.model.CommentPostDTO;
+import org.portfolio.ourverse.src.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 0. 특정 게시물에 댓글 등록하기
+    @PostMapping("/{feedId}")
+    public ResponseEntity<String> postComment(
+            @PathVariable Long feedId,
+            @RequestBody CommentPostDTO form) {
+
+        var res = commentService.postComment(feedId, form);
+
+        return ResponseEntity.ok("댓글 등록에 성공했습니다. 댓글ID : " + res);
+    }
+
+    // 1. 특정 게시물 댓글 가져오기 - 최신순
+    @GetMapping("/{feedId}")
+    public ResponseEntity<List<CommentDTO>> getComments(@PathVariable Long feedId, @RequestParam int pageNo, @RequestParam int pageSize) {
+
+        var res = commentService.getComments(feedId, pageNo, pageSize);
+
+        return ResponseEntity.ok(res);
+    }
+
+    // 2. 댓글 삭제하기
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<String> deleteComment(@PathVariable Long commentId) {
+
+        commentService.deleteComment(commentId);
+
+        return ResponseEntity.ok("댓글이 삭제됐습니다.");
+    }
+
+    // 3. 댓글 수정하기
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<String> updateComment(@PathVariable Long commentId, @RequestBody CommentPostDTO form) {
+        commentService.updateComment(commentId, form);
+
+        return ResponseEntity.ok("댓글이 수정됐습니다.");
+    }
+
+
+
+    // 4. 댓글 조회 (좋아요순)
+
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/web/CommentLikeController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/CommentLikeController.java
@@ -1,0 +1,30 @@
+package org.portfolio.ourverse.src.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment-like")
+public class CommentLikeController {
+
+    private final CommentLikeService commentLikeService;
+
+    @PostMapping("/{commentId}")
+    public ResponseEntity<String> postCommentLike(@PathVariable Long commentId) {
+
+        Long id = commentLikeService.postCommentLike(commentId);
+
+        return ResponseEntity.ok("댓글에 좋아요를 성공했습니다"+ id);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<String> deleteCommentLike(@PathVariable Long commentId) {
+
+        commentLikeService.deleteCommentLike(commentId);
+
+        return ResponseEntity.ok("댓글에 좋아요를 취소했습니다.");
+    }
+
+}

--- a/src/main/java/org/portfolio/ourverse/src/web/CommentLikeService.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/CommentLikeService.java
@@ -1,0 +1,77 @@
+package org.portfolio.ourverse.src.web;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.common.exceptions.BaseException;
+import org.portfolio.ourverse.common.exceptions.ExceptionCode;
+import org.portfolio.ourverse.src.model.UserVO;
+import org.portfolio.ourverse.src.persist.CommentLikeRepository;
+import org.portfolio.ourverse.src.persist.CommentRepository;
+import org.portfolio.ourverse.src.persist.UserRepository;
+import org.portfolio.ourverse.src.persist.entity.*;
+import org.portfolio.ourverse.src.service.AuthService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+    private final AuthService authService;
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+
+
+    @Transactional
+    public Long postCommentLike(Long commentId) {
+        UserVO userVO = authService.getCurrentUserVO();
+
+        // 1. 현재 유저 확인.
+        User user = userRepository.findById(userVO.getUserId())
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_USER));
+
+        // 2. 현재 보는 댓글 확인.
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_COMMENT));
+
+        // 3. 이미 좋아요를 한 상태인지 확인.
+        if(commentLikeRepository.findFirstByCommentAndUser(comment, user).isPresent()){
+            throw new BaseException(ExceptionCode.ALREADY_EXISTS_COMMENTLIKE);
+        }
+
+        // 4. 좋아요 등록.
+        CommentLike commentLike = CommentLike.builder()
+                .user(user)
+                .comment(comment)
+                .build();
+
+        // 5. 해당 feed의 좋아요 수 늘려주기.
+        comment.plusCommentLikeCnt();
+
+        commentLikeRepository.save(commentLike);
+
+        return commentLike.getId();
+
+    }
+
+    @Transactional
+    public void deleteCommentLike(Long commentId) {
+        UserVO userVO = authService.getCurrentUserVO();
+
+        // 1. 현재 유저 확인.
+        User user = userRepository.findById(userVO.getUserId())
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_USER));
+
+        // 2. 현재 보는 댓글 확인.
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_COMMENT));
+
+        // 3. 이미 좋아요를 한 상태인지 확인.
+        CommentLike commentLike = commentLikeRepository.findFirstByCommentAndUser(comment, user).orElseThrow(() -> new BaseException(ExceptionCode.NOT_EXISTS_COMMENTLIKE));
+
+        // 4. 좋아요 삭제
+        commentLikeRepository.delete(commentLike);
+
+        // 5. 해당 feed의 좋아요 수 줄이기.
+        comment.minusCommentLikeCnt();
+    }
+}

--- a/src/main/java/org/portfolio/ourverse/src/web/FeedController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/FeedController.java
@@ -8,6 +8,7 @@ import org.portfolio.ourverse.common.exceptions.BaseException;
 import org.portfolio.ourverse.common.exceptions.ExceptionCode;
 import org.portfolio.ourverse.src.model.FeedDTO;
 import org.portfolio.ourverse.src.model.FeedDetailDTO;
+import org.portfolio.ourverse.src.model.FeedOrderCondition;
 import org.portfolio.ourverse.src.model.FeedPostDetailDTO;
 import org.portfolio.ourverse.src.service.FeedService;
 import org.springframework.http.ResponseEntity;
@@ -40,10 +41,12 @@ public class FeedController {
     }
 
 
-    // 3. 그룹의 게시글 목록 조회 (최신순, 페이징처리)
-    // 3-1. 그룹 게시글의 최신순 정렬
-    @GetMapping("/criteria-recent")
-    public ResponseEntity<List<FeedDTO>> readAllFeedsByRecent(String groupname, int pageNo, int pageSize){
+    // 3. 그룹의 게시글 목록 조회 (최신순-좋아요순-댓글수순 동적 정렬 & 페이징처리)
+    @GetMapping
+    public ResponseEntity<List<FeedDTO>> readAllFeedsByRecent(@RequestParam String groupname,
+                                                              @RequestParam int pageNo,
+                                                              @RequestParam int pageSize,
+                                                              @RequestBody FeedOrderCondition feedOrderCondition){
         GroupName groupName;
         try{
              groupName = GroupName.valueOf(groupname);
@@ -51,35 +54,9 @@ public class FeedController {
             throw new BaseException(ExceptionCode.WRONG_GROUPNAME);
         }
 
-        return ResponseEntity.ok(feedService.readFeedAllByRecent(groupName, pageNo, pageSize));
+        return ResponseEntity.ok(feedService.readFeedAllByCrtieria(groupName, pageNo, pageSize, feedOrderCondition));
     }
 
-    // 3-2. 그룹 게시글의 좋아요 순 정렬
-    @GetMapping("/criteria-like")
-    public ResponseEntity<List<FeedDTO>> readAllFeedsByLikeCnt(String groupname, int pageNo, int pageSize){
-        GroupName groupName;
-        try{
-            groupName = GroupName.valueOf(groupname);
-        }catch (IllegalArgumentException e){
-            throw new BaseException(ExceptionCode.WRONG_GROUPNAME);
-        }
-
-        return ResponseEntity.ok(feedService.readFeedAllByLikeCnt(groupName, pageNo, pageSize));
-    }
-
-
-    // 3-3. 그룹 게시글의 댓글 순 정렬
-    @GetMapping("/criteria-comment")
-    public ResponseEntity<List<FeedDTO>> readAllFeedsByCommentCnt(String groupname, int pageNo, int pageSize){
-        GroupName groupName;
-        try{
-            groupName = GroupName.valueOf(groupname);
-        }catch (IllegalArgumentException e){
-            throw new BaseException(ExceptionCode.WRONG_GROUPNAME);
-        }
-
-        return ResponseEntity.ok(feedService.readFeedAllByCommentCnt(groupName, pageNo, pageSize));
-    }
 
 
     // 4. 그룹의 게시글 삭제 기능

--- a/src/main/java/org/portfolio/ourverse/src/web/FeedLikeController.java
+++ b/src/main/java/org/portfolio/ourverse/src/web/FeedLikeController.java
@@ -1,0 +1,27 @@
+package org.portfolio.ourverse.src.web;
+
+import lombok.RequiredArgsConstructor;
+import org.portfolio.ourverse.src.service.FeedLikeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feed-like")
+public class FeedLikeController {
+
+    private final FeedLikeService feedLikeService;
+
+    @PostMapping("/{id}")
+    public ResponseEntity<String> postFeedLike(@PathVariable Long id) {
+        Long feedLikeId = feedLikeService.postFeedLike(id);
+        return ResponseEntity.ok("좋아요에 성공했습니다 : " + feedLikeId);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteFeedLike(@PathVariable Long id) {
+        feedLikeService.deleteFeedLike(id);
+        return ResponseEntity.ok("좋아요를 취소했습니다.");
+    }
+
+}


### PR DESCRIPTION
# 개요 
댓글 CRUD 및 댓글 좋아요, 게시글 좋아요 기능 구현, QueryDSL로 게시글 및 댓글 조회 구현했습니다.
게시글의 경우 게시글좋아요, 댓글 수, 최신순으로 정렬할 수 있으며 댓글의 경우는 댓글좋아요 수, 최신순으로 정렬할 수 있습니다.

# 변경 사항
1. Comment에 대한 CRUD 기능 추가
2. QueryDSL를 설정 추가
3. QueryDSL 바탕으로 Comment에 대한 좋아요 수 순, 최신 순 정렬 기능 추가
4. Comment, Feed에 대한 좋아요 기능 추가(CommentLike, FeedLike)
5. QueryDSL 바탕으로 Feed에 대한 좋아요 수 순, 댓글 수 순, 최신 순 정렬 기능 추가
6. 게시글(Feed) 삭제 시 연관된 FeedLike, Comment, CommentLike 삭제하도록 로직 변경
7. 댓글(Comment) 삭제 시 연관된 CommentLike 삭제하도록 로직 변경
8. Readme 및 Trouble shooting 수정.

# 테스트 및 테스트 결과
[x] Comment 및 Feed의 정렬 기능이 동작하는지 확인.
[x] Feed, Comment 삭제 시 연관된 엔티티 삭제되는지 확인.

# 참고 사항
- QueryDSL 적용을 위해 intelliJ에서 Build Tools > Gradle에서, Build and run using 설정을 IntelliJ IDEA로 변경.

# 리뷰 요청 사항 및 궁금증
- 현재 상세 게시글 조회 시, 게시글 내용만 가져오고 해당 게시글의 댓글의 경우는 별도의 API로 가져와야하는 상황입니다. 저는 분리해서 구현하는게 더 낫다 생각해서 이런 방식을 택했는데, 일반적으론 게시글 내용과 함께 댓글도 모두 가져오나요?
- 현재 Feed 삭제의 구현 방식은 우선 FeedLike에서 현재 Feed에 해당하는 엔티티를 삭제하고, 현재 Feed에 해당하는 Comment를 찾아 각각의 Comment에 해당하는 CommentLike를 모두 삭제합니다. 이후 해당 Comment를 모두 삭제하는 방식으로 구현됐습니다. 이렇게 할 경우, Comment의 수 만큼 쿼리가 나가는 문제가 있습니다. 이런 경우는 Cascade.ALL와 orphanRemoval=True를 쓰는게 좋을까요?